### PR TITLE
Improve script documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # BERTopic Sustainability
 
-This repo contains example scripts for analyzing two text datasets using [BERTopic](https://github.com/MaartenGr/BERTopic). The datasets include Guardian news paragraphs and scientific paper abstracts. Each dataset is modeled separately and then compared.
+This project demonstrates how to explore large amounts of text with
+[BERTopic](https://github.com/MaartenGr/BERTopic). The example datasets include
+Guardian news paragraphs and scientific paper abstracts. Each dataset is modeled
+separately and the topics can then be compared.
 
 ## Contents
-- `analyze_guardian.py` – Fit a BERTopic model on Guardian paragraphs.
+- `analyze_guardian.py` – Fit a BERTopic model on Guardian paragraphs. Arguments
+  include `--input_file`, `--out_dir`, optional `--date_format` and `--seed`.
 - `analyze_papers.py` – Fit a BERTopic model on scientific paper abstracts.
-- `compare_topics.py` – Compare two saved BERTopic models.
+  Arguments include `--input_file`, `--out_dir` and optional `--seed`.
+- `compare_topics.py` – Compare two saved BERTopic models using `--model_a`,
+  `--model_b`, `--topics_a`, `--topics_b` and `--out_dir`.
 - `data/` – Small sample datasets (`guardian_sample.json`, `papers_sample.json`).
 
 Install dependencies with:
@@ -39,7 +45,10 @@ Raw Guardian exports such as `guardian_news_sustainability_with_content_1to5.jso
 
 ```bash
 python prepare_guardian.py guardian_news_sustainability_with_content_*.json \
-  --out_file data/guardian_all.json
+  --output_file data/guardian_all.json
 ```
 
-`prepare_guardian.py` removes the HTML, breaks articles into paragraphs and writes a single JSON file. The output records use the keys `id`, `paragraphs` and `date`, matching the format expected by `analyze_guardian.py`.
+Here `input_files` is a list of one or more raw JSON exports from the Guardian
+(wildcards are allowed). The `--output_file` argument specifies where to write
+the cleaned and merged dataset. The resulting JSON contains the keys `id`,
+`paragraphs` and `date`, ready for use with `analyze_guardian.py`.

--- a/analyze_guardian.py
+++ b/analyze_guardian.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Analyze Guardian paragraphs with BERTopic."""
+"""Analyze Guardian paragraphs with BERTopic.
+
+This script loads paragraph-level text from a Guardian export file, fits a
+BERTopic model and saves several outputs including model files, topic
+distributions and visualizations.  The input can be a CSV or JSON file with the
+columns ``id``, ``paragraphs`` and ``date``.  Results are written to the
+specified output directory.
+"""
 from __future__ import annotations
 import argparse
 from pathlib import Path
@@ -31,6 +38,8 @@ def read_data(path: str, date_format: str) -> tuple[list[str], list[datetime], l
 
 
 def ensure_requirements(outdir: Path) -> None:
+    """Write a requirements file to ``outdir`` if it does not exist."""
+
     reqs = [
         "pandas",
         "numpy",
@@ -47,6 +56,8 @@ def ensure_requirements(outdir: Path) -> None:
 
 
 def main() -> None:
+    """Command-line interface for fitting a BERTopic model."""
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--input_file", required=True)
     ap.add_argument("--date_format", default="%Y-%m-%d")

--- a/analyze_guardian.py
+++ b/analyze_guardian.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3
 """Analyze Guardian paragraphs with BERTopic.
 
-This script loads paragraph-level text from a Guardian export file, fits a
-BERTopic model and saves several outputs including model files, topic
-distributions and visualizations.  The input can be a CSV or JSON file with the
-columns ``id``, ``paragraphs`` and ``date``.  Results are written to the
-specified output directory.
+This script is intended for researchers or journalists who want to quickly
+discover themes in articles from *The Guardian*. Even if you are unfamiliar with
+topic modeling, the process is largely automated. Provide a data file with
+paragraphs, run the script, and it will group similar paragraphs together and
+create several helpful files and visualizations.
+
+Input must be a CSV or JSON file containing the columns ``id``, ``paragraphs``
+and ``date``. Key command-line arguments are:
+
+``--input_file`` – path to the CSV/JSON file.
+``--date_format`` – format string for parsing the ``date`` column. Default
+``%Y-%m-%d``.
+``--out_dir`` – directory where all outputs are saved.
+``--seed`` – random seed controlling the model initialization.
+
+Results include the trained BERTopic model, topic distributions, hierarchical
+visualizations and more. Use these files to interpret how articles discuss
+sustainability-related topics over time.
 """
 from __future__ import annotations
 import argparse

--- a/analyze_papers.py
+++ b/analyze_papers.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python3
 """Analyze scientific paper abstracts with BERTopic.
 
-The script reads a CSV or JSON file of scientific publication metadata, fits a
-BERTopic model on the abstract text and saves model outputs.  Expected input
-columns are ``paper_id``, ``abstract`` and ``pub_year``.  Various CSV files and
-HTML visualizations are written to the chosen output directory.
+If you have a dataset of academic publications and want to uncover the common
+themes, this script can help. It requires minimal expertise: supply a spreadsheet
+or JSON file with article abstracts and the year of publication, and BERTopic
+will cluster similar abstracts together.
+
+The input file must contain ``paper_id``, ``abstract`` and ``pub_year`` columns.
+Important arguments you can change:
+
+``--input_file`` – path to the CSV/JSON data file.
+``--out_dir`` – folder for saving the model and outputs.
+``--seed`` – random seed so you can reproduce the same topics.
+
+The script stores the trained model, topic distributions, temporal trends and
+an interactive hierarchy visualization inside ``out_dir``. These outputs let you
+explore how research topics evolve over the years.
 """
 from __future__ import annotations
 import argparse

--- a/analyze_papers.py
+++ b/analyze_papers.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Analyze scientific paper abstracts with BERTopic."""
+"""Analyze scientific paper abstracts with BERTopic.
+
+The script reads a CSV or JSON file of scientific publication metadata, fits a
+BERTopic model on the abstract text and saves model outputs.  Expected input
+columns are ``paper_id``, ``abstract`` and ``pub_year``.  Various CSV files and
+HTML visualizations are written to the chosen output directory.
+"""
 from __future__ import annotations
 import argparse
 from pathlib import Path
@@ -28,6 +34,8 @@ def read_data(path: str) -> tuple[list[str], list[int], list[str]]:
 
 
 def ensure_requirements(outdir: Path) -> None:
+    """Create ``requirements.txt`` in ``outdir`` if missing."""
+
     reqs = [
         "pandas",
         "numpy",
@@ -44,6 +52,8 @@ def ensure_requirements(outdir: Path) -> None:
 
 
 def main() -> None:
+    """Entry point for the papers analysis command-line tool."""
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--input_file", required=True)
     ap.add_argument("--out_dir", required=True)

--- a/compare_topics.py
+++ b/compare_topics.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
 """Compare topics from two BERTopic models.
 
-The script loads two trained BERTopic models along with their topic frequency
-over time.  It computes cosine and Jaccard similarities between the topic
-embeddings and top words, respectively, and performs a simple temporal
-correlation analysis.  Results are stored as CSV files and HTML
-visualizations in the specified output directory.
+Use this script when you have trained two separate BERTopic models—perhaps on
+different datasets—and you want to see how their topics relate. It calculates
+several similarity measures and even checks whether trends in one dataset might
+help predict the other.
+
+Provide the paths to the saved models via ``--model_a`` and ``--model_b`` along
+with the corresponding ``topics_over_time.csv`` files using ``--topics_a`` and
+``--topics_b``. ``--out_dir`` determines where the comparison results are saved.
+
+Outputs include CSV files of cosine and Jaccard similarity values, a heatmap
+visualization and a simple time-series correlation analysis. These can guide you
+in understanding how topics overlap across the two sources.
 """
 from __future__ import annotations
 import argparse

--- a/compare_topics.py
+++ b/compare_topics.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Compare topics from two BERTopic models."""
+"""Compare topics from two BERTopic models.
+
+The script loads two trained BERTopic models along with their topic frequency
+over time.  It computes cosine and Jaccard similarities between the topic
+embeddings and top words, respectively, and performs a simple temporal
+correlation analysis.  Results are stored as CSV files and HTML
+visualizations in the specified output directory.
+"""
 from __future__ import annotations
 import argparse
 from pathlib import Path
@@ -12,14 +19,20 @@ from statsmodels.tsa.stattools import grangercausalitytests
 
 
 def load_model(path: str) -> BERTopic:
+    """Load a BERTopic model from ``path``."""
+
     return BERTopic.load(path)
 
 
 def cosine_matrix(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Return pairwise cosine similarity between two embedding matrices."""
+
     return cosine_similarity(a, b)
 
 
 def jaccard_matrix(mod_a: BERTopic, mod_b: BERTopic, topn: int = 20) -> pd.DataFrame:
+    """Calculate Jaccard similarity of top words between two models."""
+
     vocab_a = {t: {w for w, _ in mod_a.get_topic(t)[:topn]} for t in mod_a.get_topics()}
     vocab_b = {t: {w for w, _ in mod_b.get_topic(t)[:topn]} for t in mod_b.get_topics()}
     jac = np.zeros((len(vocab_a), len(vocab_b)))
@@ -32,6 +45,8 @@ def jaccard_matrix(mod_a: BERTopic, mod_b: BERTopic, topn: int = 20) -> pd.DataF
 
 
 def top_matches(mat: np.ndarray, n: int = 5) -> list[tuple[int, int, float]]:
+    """Return the top ``n`` matching topic pairs for each row of ``mat``."""
+
     pairs = []
     for i in range(mat.shape[0]):
         idx = np.argsort(mat[i])[::-1][:n]
@@ -41,6 +56,8 @@ def top_matches(mat: np.ndarray, n: int = 5) -> list[tuple[int, int, float]]:
 
 
 def main() -> None:
+    """Run the topic comparison workflow from the command line."""
+
     ap = argparse.ArgumentParser()
     ap.add_argument("--model_a", required=True)
     ap.add_argument("--model_b", required=True)

--- a/prepare_guardian.py
+++ b/prepare_guardian.py
@@ -1,9 +1,14 @@
 #!/usr/bin/env python3
 """Prepare Guardian article content into paragraph-level JSON.
 
-The raw Guardian export files contain HTML under a ``content`` field.  This
-script extracts plain-text paragraphs, normalizes publication dates and writes a
-consolidated JSON file suitable for the analysis scripts in this repository.
+Guardian export files include the article text as raw HTML. This helper script
+cleans that HTML so the analysis tools have easy access to plain text. It also
+standardizes publication dates.
+
+Run the script with one or more JSON input files (``input_files`` argument) and
+specify ``--output_file`` for the combined result. The output is a new JSON file
+with the keys ``id``, ``paragraphs`` and ``date``—the structure expected by
+``analyze_guardian.py``.
 """
 from __future__ import annotations
 

--- a/prepare_guardian.py
+++ b/prepare_guardian.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Prepare Guardian article content into paragraph-level JSON."""
+"""Prepare Guardian article content into paragraph-level JSON.
+
+The raw Guardian export files contain HTML under a ``content`` field.  This
+script extracts plain-text paragraphs, normalizes publication dates and writes a
+consolidated JSON file suitable for the analysis scripts in this repository.
+"""
 from __future__ import annotations
 
 import argparse
@@ -44,6 +49,8 @@ def extract_paragraphs(html_str: str) -> list[str]:
 
 
 def process_file(path: Path) -> list[dict[str, object]]:
+    """Return cleaned paragraph data from a raw Guardian export file."""
+
     articles = json.loads(path.read_text())
     processed = []
     for art in articles:
@@ -64,6 +71,8 @@ def process_file(path: Path) -> list[dict[str, object]]:
 
 
 def main() -> None:
+    """Command-line interface for preparing Guardian content."""
+
     ap = argparse.ArgumentParser(description="Prepare Guardian HTML content")
     ap.add_argument("input_files", nargs="+", help="Input JSON files")
     ap.add_argument("--output_file", required=True, help="Output JSON file")


### PR DESCRIPTION
## Summary
- expand module docstrings for `analyze_guardian`, `analyze_papers`, `compare_topics` and `prepare_guardian`
- add descriptions to helper and main functions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685594464af08327a292554a6b2418c2