### PR TITLE
Support input_dir for Guardian prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ These commands assume you have installed the packages in `requirements.txt` and 
 Raw Guardian exports such as `guardian_news_sustainability_with_content_1to5.json` contain HTML snippets in a `content` field. To combine several of these files into a clean dataset you can run:
 
 ```bash
-python prepare_guardian.py guardian_news_sustainability_with_content_*.json \
+python prepare_guardian.py --input_dir 2_news_json_files \
   --output_file data/guardian_all.json
 ```
 
-Here `input_files` is a list of one or more raw JSON exports from the Guardian
-(wildcards are allowed). The `--output_file` argument specifies where to write
-the cleaned and merged dataset. The resulting JSON contains the keys `id`,
-`paragraphs` and `date`, ready for use with `analyze_guardian.py`.
+By default the script reads all `.json` files inside `2_news_json_files`. You
+can still pass individual paths as positional `input_files` if needed. The
+`--output_file` argument specifies where to write the cleaned and merged dataset.
+The resulting JSON contains the keys `id`, `paragraphs` and `date`, ready for
+use with `analyze_guardian.py`.

--- a/prepare_guardian.py
+++ b/prepare_guardian.py
@@ -79,13 +79,25 @@ def main() -> None:
     """Command-line interface for preparing Guardian content."""
 
     ap = argparse.ArgumentParser(description="Prepare Guardian HTML content")
-    ap.add_argument("input_files", nargs="+", help="Input JSON files")
+    ap.add_argument("input_files", nargs="*", help="Input JSON files")
+    ap.add_argument(
+        "--input_dir",
+        default="2_news_json_files",
+        help="Directory containing JSON files (default: 2_news_json_files)",
+    )
     ap.add_argument("--output_file", required=True, help="Output JSON file")
     args = ap.parse_args()
 
     all_rows: list[dict[str, object]] = []
-    for fname in args.input_files:
-        rows = process_file(Path(fname))
+    input_paths = [Path(f) for f in args.input_files]
+    if args.input_dir:
+        input_paths.extend(sorted(Path(args.input_dir).glob("*.json")))
+
+    if not input_paths:
+        ap.error("No input files found")
+
+    for path in input_paths:
+        rows = process_file(path)
         all_rows.extend(rows)
 
     Path(args.output_file).write_text(json.dumps(all_rows, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## Summary
- process default directory `2_news_json_files` when preparing Guardian data
- document new `--input_dir` option in README

## Testing
- `python -m py_compile prepare_guardian.py`
- `python -m py_compile analyze_guardian.py compare_topics.py analyze_papers.py`
- `python prepare_guardian.py guardian_news_sustainability_with_content_1to5.json --output_file test_out.json`

------
https://chatgpt.com/codex/tasks/task_e_68559a1e92308327a69b3bc953bfd793