### PR TITLE
Fix BERTopic initialization

### DIFF
--- a/analyze_guardian.py
+++ b/analyze_guardian.py
@@ -28,6 +28,7 @@ import pandas as pd
 import numpy as np
 from bertopic import BERTopic
 from sentence_transformers import SentenceTransformer
+from umap import UMAP
 import plotly.io as pio
 
 
@@ -93,11 +94,12 @@ def main() -> None:
 
     np.random.seed(args.seed)
     embedding_model = SentenceTransformer("intfloat/e5-mistral-7b-instruct")
+    umap_model = UMAP(random_state=args.seed)
     topic_model = BERTopic(
         embedding_model=embedding_model,
         calculate_probabilities=False,
         verbose=True,
-        random_state=args.seed,
+        umap_model=umap_model,
     )
     topic_model.fit(texts)
 

--- a/analyze_papers.py
+++ b/analyze_papers.py
@@ -24,6 +24,7 @@ import pandas as pd
 import numpy as np
 from bertopic import BERTopic
 from sentence_transformers import SentenceTransformer
+from umap import UMAP
 import plotly.io as pio
 
 
@@ -86,11 +87,12 @@ def main() -> None:
 
     np.random.seed(args.seed)
     embedding_model = SentenceTransformer("intfloat/e5-mistral-7b-instruct")
+    umap_model = UMAP(random_state=args.seed)
     topic_model = BERTopic(
         embedding_model=embedding_model,
         calculate_probabilities=False,
         verbose=True,
-        random_state=args.seed,
+        umap_model=umap_model,
     )
     topic_model.fit(texts)
 


### PR DESCRIPTION
## Summary
- remove unsupported `random_state` parameter when constructing `BERTopic`
- set UMAP with the provided seed to maintain reproducibility

## Testing
- `python -m py_compile analyze_guardian.py analyze_papers.py`


------
https://chatgpt.com/codex/tasks/task_e_6855a7e024d48327ab8cfd0a5b117b10