### PR TITLE
Add year-aware BERTopic workflow for papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ python analyze_papers.py --input_file data/papers_sample.json --out_dir results/
 python compare_topics.py \
   --model_a results/guardian/guardian_bertopic_model \
   --model_b results/papers/papers_bertopic_model \
-  --topics_a results/guardian/topics_over_time.csv \
-  --topics_b results/papers/topics_over_time.csv \
+  --topics_a results/guardian/topics_over_year.csv \
+  --topics_b results/papers/topics_over_year.csv \
   --out_dir results/compare
 ```
 


### PR DESCRIPTION
## Summary
- extend `topic_model_papers.py` with `--seed` and `--years` arguments
- build model with deterministic settings and compute topics over time
- save extra outputs including hierarchy and representative docs
- store publication year in `docs_topics.csv`
- document new behaviour in the script
- fix README example for renamed output files

## Testing
- `python -m py_compile analyze_guardian.py analyze_papers.py topic_model_papers.py compare_topics.py view_topics.py`


------
https://chatgpt.com/codex/tasks/task_e_68579bcde36883279ed374f7760481fc