### PR TITLE
Use calendar years for BERTopic time aggregation

### DIFF
--- a/analyze_guardian.py
+++ b/analyze_guardian.py
@@ -116,9 +116,8 @@ def main() -> None:
             return
         texts, dates, doc_ids = map(list, zip(*filtered))
 
-    # Prepare yearly timestamps for grouping by calendar year
-    unique_years = sorted({d.year for d in dates})
-    year_stamps = [datetime(year=d.year, month=1, day=1) for d in dates]
+    # Prepare year labels for grouping by calendar year
+    year_labels = pd.to_datetime(dates).year.tolist()
 
     np.random.seed(args.seed)
 
@@ -141,9 +140,8 @@ def main() -> None:
 
     tots = topic_model.topics_over_time(
         texts,
-        timestamps=year_stamps,
+        timestamps=year_labels,
         global_tuning=False,
-        nr_bins=len(unique_years),
     )
     hier = topic_model.hierarchical_topics(texts)
     distr, _ = topic_model.approximate_distribution(texts)

--- a/analyze_papers.py
+++ b/analyze_papers.py
@@ -134,10 +134,8 @@ def main() -> None:
 
         texts, years, ids = map(list, zip(*filtered))
 
-    # Prepare yearly timestamps for grouping by calendar year
-    dates = [datetime(year=y, month=1, day=1) for y in years]
-    unique_years = sorted({d.year for d in dates})
-    year_stamps = [datetime(year=d.year, month=1, day=1) for d in dates]
+    # Prepare year labels for grouping by calendar year
+    year_labels = pd.to_datetime(years, format="%Y").year.tolist()
 
     np.random.seed(args.seed)
 
@@ -160,9 +158,8 @@ def main() -> None:
 
     tots = topic_model.topics_over_time(
         texts,
-        timestamps=year_stamps,
+        timestamps=year_labels,
         global_tuning=False,
-        nr_bins=len(unique_years),
     )
     hier = topic_model.hierarchical_topics(texts)
     distr, _ = topic_model.approximate_distribution(texts)


### PR DESCRIPTION
## Summary
- group documents by integer year in `analyze_guardian.py` and `analyze_papers.py`
- remove `nr_bins` parameter when computing topics-over-time

## Testing
- `python -m py_compile analyze_guardian.py analyze_papers.py`
- `python analyze_guardian.py --help` *(fails: No module named 'bertopic')*
- `python analyze_papers.py --help` *(fails: No module named 'bertopic')*

------
https://chatgpt.com/codex/tasks/task_e_6859dd7edd58832798728ae9136e0671