### PR TITLE
Add topic hierarchy export

### DIFF
--- a/analyze_guardian.py
+++ b/analyze_guardian.py
@@ -49,6 +49,7 @@ from bertopic.representation import (
 from sentence_transformers import SentenceTransformer
 from umap import UMAP
 import plotly.io as pio
+import plotly
 
 # ---- YEAR FILTER SETTINGS (edit here or via CLI) ------------------
 START_YEAR = 2000   # first year to keep
@@ -180,6 +181,7 @@ def main() -> None:
 
     umap_model = UMAP(random_state=args.seed)
     topic_model = BERTopic(
+        nr_topics="auto",
         embedding_model=embedding_model,
         representation_model=representation_model,
         calculate_probabilities=False,
@@ -187,6 +189,14 @@ def main() -> None:
         umap_model=umap_model,
     )
     topic_model.fit(texts)
+
+    # ---- Export topic hierarchy ----
+    tree_df = topic_model.get_topic_tree()
+    tree_df.to_csv("guardian_topic_tree.csv", index=False)
+
+    fig = topic_model.visualize_hierarchy(top_n_topics=None)
+    fig.write_html("guardian_topic_tree.html")
+    # --------------------------------
 
     tots = topic_model.topics_over_time(
         texts,

--- a/analyze_papers.py
+++ b/analyze_papers.py
@@ -46,6 +46,7 @@ from bertopic.representation import (
 from sentence_transformers import SentenceTransformer
 from umap import UMAP
 import plotly.io as pio
+import plotly
 
 # ---- YEAR FILTER SETTINGS (edit here or via CLI) ------------------
 START_YEAR = 2000   # first year to keep
@@ -201,6 +202,7 @@ def main() -> None:
 
     umap_model = UMAP(random_state=args.seed)
     topic_model = BERTopic(
+        nr_topics="auto",
         embedding_model=embedding_model,
         representation_model=representation_model,
         calculate_probabilities=False,
@@ -208,6 +210,14 @@ def main() -> None:
         umap_model=umap_model,
     )
     topic_model.fit(texts)
+
+    # ---- Export topic hierarchy ----
+    tree_df = topic_model.get_topic_tree()
+    tree_df.to_csv("papers_topic_tree.csv", index=False)
+
+    fig = topic_model.visualize_hierarchy(top_n_topics=None)
+    fig.write_html("papers_topic_tree.html")
+    # --------------------------------
 
     tots = topic_model.topics_over_time(
         texts,


### PR DESCRIPTION
## Summary
- automatically let BERTopic choose number of topics
- export BERTopic hierarchy tree for Guardian and Papers runs
- ensure plotly is imported for hierarchy export

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bf8ce92a483278c30ce56f2b164fb