### PR TITLE
Fix BERTopic tree handling

### DIFF
--- a/analyze_guardian.py
+++ b/analyze_guardian.py
@@ -200,8 +200,11 @@ def main() -> None:
 
     # Topic reduction removed in BERTopic >= 0.17
     hier = topic_model.hierarchical_topics(texts)
-    tree_df = topic_model.get_topic_tree(hier)
-    tree_df.to_csv(out_dir / "topic_tree.csv", index=False)
+    tree = topic_model.get_topic_tree(hier)
+    if hasattr(tree, "to_csv"):
+        tree.to_csv(out_dir / "topic_tree.csv", index=False)
+    else:
+        Path(out_dir, "topic_tree.txt").write_text(str(tree))
 
     fig = topic_model.visualize_hierarchy(top_n_topics=None)
     fig.write_html("guardian_topic_tree.html")

--- a/analyze_papers.py
+++ b/analyze_papers.py
@@ -226,8 +226,11 @@ def main() -> None:
 
     topic_model.reduce_topics(texts, threshold=args.threshold)
     hier = topic_model.hierarchical_topics(texts)
-    tree_df = topic_model.get_topic_tree(hier)
-    tree_df.to_csv(out_dir / "topic_tree.csv", index=False)
+    tree = topic_model.get_topic_tree(hier)
+    if hasattr(tree, "to_csv"):
+        tree.to_csv(out_dir / "topic_tree.csv", index=False)
+    else:
+        Path(out_dir, "topic_tree.txt").write_text(str(tree))
 
     fig = topic_model.visualize_hierarchy(top_n_topics=None)
     fig.write_html("papers_topic_tree.html")


### PR DESCRIPTION
## Summary
- adapt analyze scripts for BERTopic versions where `get_topic_tree` returns a string
- write `topic_tree.csv` when available, otherwise create `topic_tree.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ceb46a8708327bbb471e47d4303e6